### PR TITLE
[#125984363] Update logout logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "2.3.0"
 
 gem "active_model_serializers"
 gem "bcrypt"
-gem "ffaker"
+gem "faker"
 gem "figaro"
 gem "jwt"
 gem "oj"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,8 @@ GEM
     factory_girl_rails (4.7.0)
       factory_girl (~> 4.7.0)
       railties (>= 3.0.0)
-    ffaker (2.2.0)
+    faker (1.6.3)
+      i18n (~> 0.5)
     ffi (1.9.10)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -266,7 +267,7 @@ DEPENDENCIES
   coveralls
   database_cleaner
   factory_girl_rails
-  ffaker
+  faker
   figaro
   guard
   guard-rspec

--- a/app/controllers/api/authentication_controller.rb
+++ b/app/controllers/api/authentication_controller.rb
@@ -11,6 +11,7 @@ module Api
     end
 
     def logout
+      current_user.invalid_tokens.create!(token: token)
       @current_user = nil
 
       data = { message: ExceptionMessages::Messages.logged_out }

--- a/app/controllers/api/authentication_controller.rb
+++ b/app/controllers/api/authentication_controller.rb
@@ -11,7 +11,6 @@ module Api
     end
 
     def logout
-      current_user.update_attribute(:logged_in, false)
       @current_user = nil
 
       data = { message: ExceptionMessages::Messages.logged_out }

--- a/app/models/invalid_token.rb
+++ b/app/models/invalid_token.rb
@@ -1,0 +1,7 @@
+class InvalidToken < ActiveRecord::Base
+  belongs_to :user
+
+  validates :token,
+            presence: true,
+            uniqueness: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ActiveRecord::Base
   has_many :buckets, foreign_key: :created_by
+  has_many :invalid_tokens
   before_save do
     self.email = email.downcase
   end

--- a/app/services/api_authorize_service.rb
+++ b/app/services/api_authorize_service.rb
@@ -4,7 +4,7 @@ class ApiAuthorizeService
   end
 
   def authorize
-    user
+    { user: user, token: http_auth_header }
   end
 
   private

--- a/app/services/api_authorize_service.rb
+++ b/app/services/api_authorize_service.rb
@@ -13,8 +13,6 @@ class ApiAuthorizeService
 
   def user
     @user ||= User.find(decoded_auth_token[:user_id]) if decoded_auth_token
-    raise ExceptionHandlers::NotAuthenticatedError,
-          ExceptionMessages::Messages.not_auth unless @user.logged_in
     @user
   end
 

--- a/app/services/authentication_service.rb
+++ b/app/services/authentication_service.rb
@@ -12,10 +12,7 @@ class AuthenticationService
   end
 
   def login
-    if user
-      user.update_attribute(:logged_in, true)
-      JsonWebToken.encode(user_id: user.id)
-    end
+    JsonWebToken.encode(user_id: user.id) if user
   end
 
   private
@@ -27,6 +24,6 @@ class AuthenticationService
     return user if user && user.authenticate(password)
 
     raise ExceptionHandlers::AccessDeniedError,
-          ExceptionMessages::Messages.access_denied
+      ExceptionMessages::Messages.access_denied
   end
 end

--- a/app/services/authentication_service.rb
+++ b/app/services/authentication_service.rb
@@ -24,6 +24,6 @@ class AuthenticationService
     return user if user && user.authenticate(password)
 
     raise ExceptionHandlers::AccessDeniedError,
-      ExceptionMessages::Messages.access_denied
+          ExceptionMessages::Messages.access_denied
   end
 end

--- a/db/migrate/20160709223649_remove_loggedin_from_user.rb
+++ b/db/migrate/20160709223649_remove_loggedin_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveLoggedinFromUser < ActiveRecord::Migration
+  def change
+    remove_column :users, :logged_in
+  end
+end

--- a/db/migrate/20160709225221_create_invalid_tokens.rb
+++ b/db/migrate/20160709225221_create_invalid_tokens.rb
@@ -1,0 +1,10 @@
+class CreateInvalidTokens < ActiveRecord::Migration
+  def change
+    create_table :invalid_tokens do |t|
+      t.references :user, index: true, foreign_key: true
+      t.string :token
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160706160147) do
+ActiveRecord::Schema.define(version: 20160709223649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,11 +34,10 @@ ActiveRecord::Schema.define(version: 20160706160147) do
   add_index "items", ["bucket_id"], name: "index_items_on_bucket_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                           null: false
-    t.string   "password_digest",                 null: false
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.boolean  "logged_in",       default: false
+    t.string   "email",           null: false
+    t.string   "password_digest", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160709223649) do
+ActiveRecord::Schema.define(version: 20160709225221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,15 @@ ActiveRecord::Schema.define(version: 20160709223649) do
     t.datetime "updated_at", null: false
     t.integer  "created_by"
   end
+
+  create_table "invalid_tokens", force: :cascade do |t|
+    t.integer  "user_id"
+    t.string   "token"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "invalid_tokens", ["user_id"], name: "index_invalid_tokens_on_user_id", using: :btree
 
   create_table "items", force: :cascade do |t|
     t.string   "name"
@@ -42,5 +51,6 @@ ActiveRecord::Schema.define(version: 20160709223649) do
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
 
+  add_foreign_key "invalid_tokens", "users"
   add_foreign_key "items", "buckets"
 end

--- a/lib/tasks/token_cleanup.rake
+++ b/lib/tasks/token_cleanup.rake
@@ -1,0 +1,13 @@
+namespace :token do
+  desc "Delete expired tokens"
+  task clean_expired: :environment do
+    puts "Deleting expired tokens from InvalidToken table..."
+    InvalidToken.all.pluck(:token).each do |token|
+      begin
+        JsonWebToken.decode(token)
+      rescue JWT::ExpiredSignature, JWT::VerificationError, JWT::DecodeError
+        InvalidToken.find_by(token: token).destroy
+      end
+    end
+  end
+end

--- a/spec/controllers/api/authentication_controller_spec.rb
+++ b/spec/controllers/api/authentication_controller_spec.rb
@@ -54,6 +54,23 @@ RSpec.describe Api::AuthenticationController, type: :controller do
         expect(response).to be_success
         expect(json.fetch("message")).
           to eql ExceptionMessages::Messages.logged_out
+        expect(user.invalid_tokens.pluck(:token)).
+          to include headers[:authorization]
+      end
+    end
+
+    context "When a user is already logged out" do
+      before do
+        post :login, param
+        get :logout
+      end
+
+      it "returns an expired signature error message" do
+        get :logout
+
+        expect(response).to have_http_status 401
+        expect(json.fetch("errors")).
+          to eql ExceptionMessages::Messages.expired_sig
       end
     end
   end

--- a/spec/controllers/api/authentication_controller_spec.rb
+++ b/spec/controllers/api/authentication_controller_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Api::AuthenticationController, type: :controller do
     context "When an anonymous user tries to login" do
       it "returns an error message" do
         err_param = {
-          email: FFaker::Internet.safe_email,
-          password: FFaker::Internet.password
+          email: Faker::Internet.safe_email,
+          password: Faker::Internet.password
         }
         post :login, err_param
 

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Api::UsersController, type: :controller do
 
       it "returns validation error if params invalid" do
         param = {
-          email: FFaker::Lorem.word,
-          password: FFaker::Internet.password
+          email: Faker::Lorem.word,
+          password: Faker::Internet.password
         }
         post :create, param
 

--- a/spec/controllers/api/v1/buckets_controller_spec.rb
+++ b/spec/controllers/api/v1/buckets_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::BucketsController, type: :controller do
-  let(:user) { create(:logged_in_user) }
+  let(:user) { create(:user) }
   let(:auth_token) { token(user) }
   let(:bucket) { create(:bucket) }
   let(:valid_attributes) { attributes_for(:bucket) }

--- a/spec/controllers/api/v1/items_controller_spec.rb
+++ b/spec/controllers/api/v1/items_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::ItemsController, type: :controller do
-  let(:user) { create(:logged_in_user) }
+  let(:user) { create(:user) }
   let(:auth_token) { token(user) }
   let(:item) { create(:bucket_item) }
   let(:valid_attributes) { attributes_for(:bucket_item) }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ApplicationController, type: :request do
   describe "Undefined endpoints" do
     context "when a user visits a non-existing endpoint" do
       it "responds with a 404 - not found error" do
-        route = FFaker::Lorem.word
+        route = Faker::Lorem.word
         get "/#{route}", {}, headers
 
         expect(response).to have_http_status 404

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ApplicationController, type: :request do
-  let(:user) { create(:user, logged_in: true) }
+  let(:user) { create(:user) }
   let(:auth_token) { token(user) }
   let(:headers) do
     {

--- a/spec/factories/buckets.rb
+++ b/spec/factories/buckets.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :bucket do
-    name { FFaker::CheesyLingo.title }
+    name { Faker::Book.title }
     created_by 1
     items do
       [].tap do |items|

--- a/spec/factories/invalid_tokens.rb
+++ b/spec/factories/invalid_tokens.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :invalid_token do
+    token { Faker::Bitcoin.address }
+  end
+end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :item do
-    name { FFaker::Movie.title }
-    done { FFaker::Boolean.random }
+    name { Faker::StarWars.character }
+    done { Faker::Boolean.boolean }
 
     factory :invalid_item do
       name nil

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :user do
-    email { FFaker::Internet.safe_email }
-    password { FFaker::Internet.password }
+    email { Faker::Internet.safe_email }
+    password { Faker::Internet.password }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,9 +2,5 @@ FactoryGirl.define do
   factory :user do
     email { FFaker::Internet.safe_email }
     password { FFaker::Internet.password }
-
-    factory :logged_in_user do
-      logged_in true
-    end
   end
 end

--- a/spec/models/bucket_spec.rb
+++ b/spec/models/bucket_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Bucket, type: :model do
     end
 
     it "searches for matching buckets" do
-      datum = FFaker::CheesyLingo.title
+      datum = Faker::StarWars.character
       search_bucket = create(:bucket, name: datum)
       create_list(:bucket, 5)
 

--- a/spec/models/invalid_token_spec.rb
+++ b/spec/models/invalid_token_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe InvalidToken, type: :model do
+  subject { create(:invalid_token) }
+
+  describe "Model validation" do
+    it { should be_valid }
+    it { should validate_presence_of(:token) }
+    it { should validate_uniqueness_of(:token) }
+    it { should belong_to(:user) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
-  let(:email) { FFaker::Internet.safe_email }
+  let(:email) { Faker::Internet.safe_email }
   subject { create(:user, email: email.upcase) }
 
   describe "Model validation" do
@@ -13,8 +13,8 @@ RSpec.describe User, type: :model do
     it { should have_many(:buckets).with_foreign_key("created_by") }
     it do
       should_not allow_values(
-        FFaker::Internet.domain_name,
-        FFaker::Internet.domain_suffix
+        Faker::Internet.domain_word,
+        Faker::Internet.domain_suffix
       ).for(:email)
     end
     it "downcases emails" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe User, type: :model do
     it { should validate_presence_of(:email) }
     it { should validate_uniqueness_of(:email).case_insensitive }
     it { should have_many(:buckets).with_foreign_key("created_by") }
+    it { should have_many(:invalid_tokens) }
     it do
       should_not allow_values(
         Faker::Internet.domain_word,

--- a/spec/repositories/resources_repo_spec.rb
+++ b/spec/repositories/resources_repo_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ResourcesRepo do
   let(:bucket) { create(:bucket, created_by: user.id) }
   let(:params) do
     {
-      name: FFaker::CheesyLingo.title
+      name: Faker::StarWars.character
     }
   end
   subject(:repo) { described_class.new(user, bucket.id) }

--- a/spec/services/api_authorize_services_spec.rb
+++ b/spec/services/api_authorize_services_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ApiAuthorizeService do
 
   describe "Authorize user" do
     it "authorize user using the authorization header" do
-      expect(service(auth_headers(user)).authorize).
+      expect(service(auth_headers(user)).authorize[:user]).
         to eql user
     end
 
@@ -26,9 +26,8 @@ RSpec.describe ApiAuthorizeService do
     end
 
     it "raises error if token is incorrect" do
-      fake_token = Faker::Bitcoin.address
       expect do
-        service("Authorization" => fake_token).authorize
+        service("Authorization" => Faker::Bitcoin.address).authorize
       end.to raise_error ExceptionHandlers::NotAuthenticatedError
     end
 

--- a/spec/services/api_authorize_services_spec.rb
+++ b/spec/services/api_authorize_services_spec.rb
@@ -26,8 +26,9 @@ RSpec.describe ApiAuthorizeService do
     end
 
     it "raises error if token is incorrect" do
+      fake_token = Faker::Bitcoin.address
       expect do
-        service("Authorization" => FFaker::Guid.guid).authorize
+        service("Authorization" => fake_token).authorize
       end.to raise_error ExceptionHandlers::NotAuthenticatedError
     end
 

--- a/spec/services/api_authorize_services_spec.rb
+++ b/spec/services/api_authorize_services_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ApiAuthorizeService do
-  let(:logged_out_user) { create(:user) }
-  let(:logged_in_user) { create(:logged_in_user) }
+  let(:user) { create(:user) }
 
   def auth_headers(user_type)
     {
@@ -16,14 +15,8 @@ RSpec.describe ApiAuthorizeService do
 
   describe "Authorize user" do
     it "authorize user using the authorization header" do
-      expect(service(auth_headers(logged_in_user)).authorize).
-        to eql logged_in_user
-    end
-
-    it "raises an error if user not logged in" do
-      expect do
-        service(auth_headers(logged_out_user)).authorize
-      end.to raise_error ExceptionHandlers::NotAuthenticatedError
+      expect(service(auth_headers(user)).authorize).
+        to eql user
     end
 
     it "raises an error if authorization header missing" do
@@ -42,7 +35,7 @@ RSpec.describe ApiAuthorizeService do
       Timecop.travel(2.month.from_now)
 
       expect do
-        service(auth_headers(logged_in_user)).authorize
+        service(auth_headers(user)).authorize
       end.to raise_error ExceptionHandlers::ExpiredSignatureError
 
       Timecop.return

--- a/spec/services/authentication_services_spec.rb
+++ b/spec/services/authentication_services_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe AuthenticationService do
     context "when the user is anonymous" do
       subject do
         described_class.new(
-          FFaker::Internet.safe_email,
-          FFaker::Internet.password
+          Faker::Internet.safe_email,
+          Faker::Internet.password
         )
       end
 
@@ -46,7 +46,7 @@ RSpec.describe AuthenticationService do
     context "when a user signsup with invalid parameters" do
       subject do
         described_class.new(
-          FFaker::Lorem.word,
+          Faker::Lorem.word,
           new_user_attrs[:password]
         )
       end

--- a/spec/services/authentication_services_spec.rb
+++ b/spec/services/authentication_services_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe AuthenticationService do
 
       it "Logs in a user" do
         subject.login
-        expect(User.find(user.id).logged_in).to be_truthy
       end
     end
 


### PR DESCRIPTION
#### What does this PR do?
- Create `InvalidToken` model to store tokens when a user logs out.
- Compare incoming requests against Invalid tokens.
- Create rake task that deletes expired tokens from InvalidToken.
- Remove previous logic which involved a `logged_in` flag.
- Swap `FFaker` for `Faker` gem for random data generation.
#### Description of Task to be completed?

Improve the user log out logic.
#### What are the relevant pivotal tracker stories?

[#125984363]
